### PR TITLE
Why: Add imgui_tables.cpp to CMakeLists.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -13,11 +13,11 @@
 #     will be a sibling of the cmakefied directory.
 #
 
-cd "$(dirname $0)/.."
+cd "$(dirname "$0")/.."
 deps_dir=$PWD
 cd - >/dev/null
 
-cd "$(dirname $0)"
+cd "$(dirname "$0")"
 cmakefied_dir=$PWD
 cd - >/dev/null
 
@@ -47,7 +47,7 @@ gitit () {
     cp -Rv "$cmakefied_dir/$2"/* "$dir"
 }
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
     if [[ $1 =~ --dir=(.*) ]]; then
         deps_dir="${BASH_REMATCH[1]}"
         shift
@@ -55,16 +55,16 @@ while [[ $# > 0 ]]; do
     fi
     case $1 in
         imgui)
-            gitit "https://github.com/ocornut/imgui.git" $1
+            gitit "https://github.com/ocornut/imgui.git" "$1"
             ;;
         Box2D)
-            gitit "https://github.com/erincatto/Box2D.git" $1
+            gitit "https://github.com/erincatto/Box2D.git" "$1"
             ;;
         combinations)
-            gitit "https://github.com/HowardHinnant/combinations.git" $1
+            gitit "https://github.com/HowardHinnant/combinations.git" "$1"
             ;;
         eigen)
-            gitit "https://github.com/RLovelett/eigen.git" $1 "branches/3.3"
+            gitit "https://github.com/RLovelett/eigen.git" "$1" "branches/3.3"
             ;;
         *)
             echo "Invalid package: $1" >&2

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -10,7 +10,8 @@ set(phdrs ${root}/imgui.h)
 set(hdrs ${root}/imstb_rectpack.h ${root}/imstb_textedit.h ${root}/imstb_truetype.h
     ${root}/imgui_internal.h)
 set(srcs ${root}/imgui.cpp
-    ${root}/imgui_demo.cpp ${root}/imgui_draw.cpp ${root}/imgui_widgets.cpp)
+    ${root}/imgui_demo.cpp ${root}/imgui_draw.cpp ${root}/imgui_widgets.cpp
+    ${root}/imgui_tables.cpp)
 
 add_library(imgui STATIC ${phdrs} ${hdrs} ${srcs})
 target_include_directories(imgui PUBLIC

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -27,7 +27,7 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
     message(STATUS "OpenGL, GLEW and GLFW found, installing imgui::glfw-gl3-glew.")
 
     # replace #include gl3w.h with glew.h
-    file(STRINGS examples/opengl3_example/imgui_impl_glfw_gl3.cpp cppcontent)
+    file(STRINGS examples/example_glfw_opengl3/main.cpp cppcontent)
     set(cppcontent-glew "")
     foreach(l ${cppcontent})
         if(l MATCHES "#include.*GL/gl3w.h")
@@ -40,14 +40,19 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
 
     add_library(glfw-gl3-glew STATIC
         "${modified_cpp}"
-        examples/opengl3_example/imgui_impl_glfw_gl3.h
+        backends/imgui_impl_opengl3.h
+    )
+    add_library(glfw-gl3-glew STATIC
+        "${modified_cpp}"
+        backends/imgui_impl_glfw.h
     )
     target_include_directories(glfw-gl3-glew PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/examples/opengl3_example>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/backends>
         $<INSTALL_INTERFACE:include>)
     target_link_libraries(glfw-gl3-glew PUBLIC OpenGL::GL GLEW::glew_s glfw imgui)
     list(APPEND targets glfw-gl3-glew)
-    list(APPEND headers_to_install examples/opengl3_example/imgui_impl_glfw_gl3.h)
+    list(APPEND headers_to_install backends/imgui_impl_opengl3.h)
+    list(APPEND headers_to_install backends/imgui_impl_glfw.h)
 else()
     if(NOT OPENGL_FOUND)
         message(STATUS "OpenGL not found, not installing imgui::glfw-gl3-glew.")

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -41,9 +41,6 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
     add_library(glfw-gl3-glew STATIC
         "${modified_cpp}"
         backends/imgui_impl_opengl3.h
-    )
-    add_library(glfw-gl3-glew STATIC
-        "${modified_cpp}"
         backends/imgui_impl_glfw.h
     )
     target_include_directories(glfw-gl3-glew PUBLIC

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -17,7 +17,9 @@ add_library(imgui STATIC ${phdrs} ${hdrs} ${srcs})
 target_include_directories(imgui PUBLIC
     $<BUILD_INTERFACE:${root}>
     $<INSTALL_INTERFACE:include>)
-target_compile_definitions(imgui PUBLIC IMGUI_DISABLE_INCLUDE_IMCONFIG_H)
+target_compile_definitions(
+    imgui PUBLIC IMGUI_DISABLE_INCLUDE_IMCONFIG_H
+    $<$<BOOL:${IMGUI_DISABLE_OBSOLETE_FUNCTIONS}>:IMGUI_DISABLE_OBSOLETE_FUNCTIONS>)
 set_target_properties(imgui PROPERTIES DEBUG_POSTFIX "d")
 
 set(targets imgui)


### PR DESCRIPTION
New change in Dear Imgui added a new cpp file (imgui_tables.cpp) that
must be included in the build (see below commit for reference)

https://github.com/ocornut/imgui/commit/9874077fc0e364383ef997e3d4332172bfddc0b9

Cheers!

Tom